### PR TITLE
feat: #2 H1, P, YoutubePlayer Component

### DIFF
--- a/src/components/common/H1.tsx
+++ b/src/components/common/H1.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { _H1 } from '../../styles/common';
+
+interface H1Props {
+  center?: boolean;
+
+  children?: React.ReactNode;
+}
+
+const H1 = ({ center, children }: H1Props) => (
+  <_H1 style={{ textAlign: center ? 'center' : 'left' }}>{children}</_H1>
+);
+
+export default H1;

--- a/src/components/common/P.tsx
+++ b/src/components/common/P.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { _P } from '../../styles/common';
+
+interface PProps {
+  center?: boolean;
+
+  children?: React.ReactNode;
+}
+
+const P = ({ center, children }: PProps) => (
+  <_P style={{ textAlign: center ? 'center' : 'left' }}>{children}</_P>
+);
+
+export default P;

--- a/src/components/home/YoutubePlayer/index.tsx
+++ b/src/components/home/YoutubePlayer/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  YoutubeBox,
+  YoutubeFrame,
+  Contents,
+} from '../../../styles/home/YoutubePlayer';
+
+interface YoutubePlayerProps {
+  videoID: string;
+  autoplay?: boolean;
+  mute?: boolean;
+  loop?: boolean;
+  controls?: boolean;
+  disableKeyboard?: boolean;
+
+  children?: React.ReactNode;
+}
+
+const YoutubePlayer = ({
+  videoID,
+  autoplay,
+  mute,
+  loop,
+  controls,
+  disableKeyboard,
+  children,
+}: YoutubePlayerProps) => {
+  const src = `https://www.youtube.com/embed/${videoID}?autoplay=${
+    autoplay ? '1' : '0'
+  }&mute=${mute ? '1' : '0'}&loop=${
+    loop ? '1' : '0'
+  }&playlist=${videoID}&controls=${
+    controls ? '1' : '0'
+  }&modestbranding=1&disablekb=${disableKeyboard ? '1' : '0'}&iv_load_policy=3`;
+
+  return (
+    <React.Fragment>
+      <YoutubeBox>
+        <YoutubeFrame src={src} frameBorder={0} allowFullScreen={false} />;
+      </YoutubeBox>
+      <Contents>{children}</Contents>
+    </React.Fragment>
+  );
+};
+
+export default YoutubePlayer;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,21 @@
-import { Start, Wrapper } from "../styles/start";
+import { Wrapper } from '../styles/start';
+import YoutubePlayer from '../components/home/YoutubePlayer';
+import H1 from '../components/common/H1';
+import P from '../components/common/P';
 
-export default function Home() {
-  return (
-    <Wrapper>
-      <Start>Let's Start!</Start>
-    </Wrapper>//example
-  )
-}
+const Home = () => (
+  <Wrapper>
+    <YoutubePlayer videoID='sqgxcCjD04s' autoplay mute loop disableKeyboard>
+      <H1 center>NL 세상의 중심이 되다.</H1>
+      <P>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc mauris
+        magna, sollicitudin in porttitor et, vestibulum quis ligula. Sed porta
+        et mi vel tincidunt. Morbi eleifend rutrum ornare. Vestibulum hendrerit
+        lacinia venenatis. Curabitur et mi urna. Aliquam dignissim a ipsum nec
+        bibendum. Integer tristique imperdiet accumsan. Cras et accumsan lorem.
+      </P>
+    </YoutubePlayer>
+  </Wrapper>
+);
+
+export default Home;

--- a/src/styles/common.tsx
+++ b/src/styles/common.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const _H1 = styled.h1`
+  font-size: 48px;
+  font-weight: bold;
+  margin-bottom: 24px;
+
+  text-align: ${(props) => props.style?.textAlign};
+`;
+
+export const _P = styled.p`
+  font-size: 16px;
+  font-weight: lighter;
+
+  text-align: ${(props) => props.style?.textAlign};
+`;

--- a/src/styles/home/YoutubePlayer.tsx
+++ b/src/styles/home/YoutubePlayer.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+export const YoutubeBox = styled('div')`
+  width: 100vw;
+  height: calc(100vh - 100px);
+  overflow: hidden;
+`;
+
+export const YoutubeFrame = styled('iframe')`
+  width: 100vw;
+  height: max(100%, calc(100vw / 16 * 9));
+
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const Contents = styled('div')`
+  display: flex;
+  flex-direction: column;
+
+  position: absolute;
+  top: calc(50vh + 50px);
+  left: 50vw;
+  transform: translate(-50%, -50%);
+
+  color: white;
+  text-shadow: -1px 0px black, 0px 1px black, 1px 0px black, 0px -1px black;
+`;


### PR DESCRIPTION
# 작업 내용

## Common Components

`_H1`, `_P` styled-component 를 `src/styles` 에 작성하고

styled-component에 `props` 를 전달하는 `H1`, `P` 컴포넌트를 `src/components/common` 에 작성했습니다

<img width="285" alt="스크린샷 2022-04-03 04 24 47" src="https://user-images.githubusercontent.com/49232918/161398149-ffa01988-81e7-4b5d-bbd5-e366228341c6.png">

## YoutubePlayer Component

유튜브를 재생하고 자식 컴포넌트를 영상 중앙에 표시하는 컴포넌트를 작성했습니다

<img width="1440" alt="스크린샷 2022-04-03 04 25 23" src="https://user-images.githubusercontent.com/49232918/161398171-049fa0ca-2e16-4ca9-88ad-4705ac06428c.png">

# 공유 사항

`src/components/common` 디렉토리 아래에 기본 컴포넌트를 하나씩 작성하니까 import 를 따로 해야해서 불편해요..

```ts
import H1 from '...'
import P from '...'
```